### PR TITLE
#22 Use global vars for theme

### DIFF
--- a/libs/styles/src/components/_set-components.scss
+++ b/libs/styles/src/components/_set-components.scss
@@ -1,22 +1,11 @@
 @use 'sass:map';
 @import './default-components';
-@import '../utility/scss-map-to-css-vars';
+@import '../utility/nested-map-to-css-vars';
 
 @mixin set-components($components-config: ()) {
   $components: map.deep-merge($default-components, $components-config);
 
-  $current-palette: 'light' !global;
   :root {
-    color-scheme: light;
-    @include scss-map-to-css-vars($components, 'react-bedrock');
-  }
-
-  @each $name, $value in map.get($theme, 'palette') {
-    $current-palette: $name !global;
-
-    :root[data-theme='#{$current-palette}'] {
-      color-scheme: $current-palette;
-      @include scss-map-to-css-vars($components, 'react-bedrock');
-    }
+    @include nested-map-to-css-vars($components, 'react-bedrock');
   }
 }

--- a/libs/styles/src/components/button/_default-button.scss
+++ b/libs/styles/src/components/button/_default-button.scss
@@ -1,200 +1,128 @@
-@use 'sass:map';
-@use 'sass:color';
-
-@function primary-main-color($current-palette) {
-  @return --react-bedrock-theme-palette-#{$current-palette}-primary-main
-}
-
 $default-button: (
   'contained': (
-    'shadow': --react-bedrock-theme-shadow-box-xs,
+    'shadow': var(--react-bedrock-theme-shadow-box-xs),
     'primary': (
       'background': (
-        'color': --react-bedrock-theme-palette-#{$current-palette}-primary-main,
+        'color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-main),
       ),
       'text': (
-        'color': --react-bedrock-theme-palette-#{$current-palette}-primary-contrast-text
+        'color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-contrast-text)
       ),
       'hover': (
         'background': (
-          'color':
-            color.scale(
-              primary-main-color($current-palette),
-              $lightness: -10%
-            ),
+          'color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-light)
         ),
       ),
     ),
     'secondary': (
       'background': (
-        'color':
-          map.get($theme, 'palette', $current-palette, 'secondary', 'main'),
+        'color': var(--react-bedrock-theme-palette-#{$current-palette}-secondary-main)
       ),
       'text': (
-        'color':
-          map.get(
-            $theme,
-            'palette',
-            $current-palette,
-            'secondary',
-            'contrast-text'
-          ),
+        'color': var(--react-bedrock-theme-palette-#{$current-palette}-secondary-contrast-text)
       ),
       'hover': (
         'background': (
-          'color':
-            darken(
-              map.get($theme, 'palette', $current-palette, 'secondary', 'main'),
-              10%
-            ),
+          'color': var(--react-bedrock-theme-palette-#{$current-palette}-secondary-light)
         ),
       ),
     ),
     'accent': (
       'background': (
-        'color': map.get($theme, 'palette', $current-palette, 'accent', 'main'),
+        'color': var(--react-bedrock-theme-palette#{$current-palette}-accent-main),
       ),
       'text': (
-        'color':
-          map.get(
-            $theme,
-            'palette',
-            $current-palette,
-            'accent',
-            'contrast-text'
-          ),
+        'color': var(--react-bedrock-theme-palette-#{$current-palette}-accent-contrast-text)
       ),
       'hover': (
         'background': (
-          'color':
-            darken(
-              map.get($theme, 'palette', $current-palette, 'accent', 'main'),
-              10%
-            ),
+          'color': var(--react-bedrock-theme-palette-#{$current-palette}-accent-light)
         ),
       ),
     ),
   ),
   'outlined': (
-    'shadow': map.get($theme, 'shadow', 'box', 'xs'),
-    'border': map.get($theme, 'border', 'thin'),
+    'shadow': var(--react-bedrock-theme-shadow-box-xs),
+    'border': var(--react-bedrock-theme-border-thin),
     'primary': (
       'border': (
-        'color': map.get($theme, 'palette', $current-palette, 'primary', 'main'),
+        'color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-main),
       ),
       'text': (
-        'color': map.get($theme, 'palette', $current-palette, 'primary', 'main'),
+        'color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-main),
       ),
       'hover': (
         'border': (
-          'color':
-            darken(
-              map.get($theme, 'palette', $current-palette, 'primary', 'main'),
-              10%
-            ),
+          'color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-light)
         ),
         'text': (
-          'color':
-            darken(
-              map.get($theme, 'palette', $current-palette, 'primary', 'main'),
-              10%
-            ),
+          'color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-light)
         ),
       ),
     ),
     'secondary': (
       'border': (
-        'color':
-          map.get($theme, 'palette', $current-palette, 'secondary', 'main'),
+        'color': var(--react-bedrock-theme-palette-#{$current-palette}-secondary-main),
       ),
       'text': (
-        'color':
-          map.get($theme, 'palette', $current-palette, 'secondary', 'main'),
+        'color': var(--react-bedrock-theme-palette-#{$current-palette}-secondary-main),
       ),
       'hover': (
         'border': (
-          'color':
-            darken(
-              map.get($theme, 'palette', $current-palette, 'secondary', 'main'),
-              10%
-            ),
+          'color': var(--react-bedrock-theme-palette-#{$current-palette}-secondary-light)
         ),
         'text': (
-          'color':
-            darken(
-              map.get($theme, 'palette', $current-palette, 'secondary', 'main'),
-              10%
-            ),
+          'color': var(--react-bedrock-theme-palette-#{$current-palette}-secondary-light)
         ),
       ),
     ),
     'accent': (
       'border': (
-        'color': map.get($theme, 'palette', $current-palette, 'accent', 'main'),
+        'color': var(--react-bedrock-theme-palette-#{$current-palette}-accent-main),
       ),
       'text': (
-        'color': map.get($theme, 'palette', $current-palette, 'accent', 'main'),
+        'color': var(--react-bedrock-theme-palette-#{$current-palette}-accent-main),
       ),
       'hover': (
         'border': (
-          'color':
-            darken(
-              map.get($theme, 'palette', $current-palette, 'accent', 'main'),
-              10%
-            ),
+          'color': var(--react-bedrock-theme-palette-#{$current-palette}-accent-light)
         ),
         'text': (
-          'color':
-            darken(
-              map.get($theme, 'palette', $current-palette, 'accent', 'main'),
-              10%
-            ),
+          'color': var(--react-bedrock-theme-palette-#{$current-palette}-accent-light)
         ),
       ),
     ),
   ),
   'text': (
-    'shadow': map.get($theme, 'shadow', 'box', 'none'),
+    'shadow': var(--react-bedrock-theme-shadow-box-none),
     'primary': (
       'text': (
-        'color': map.get($theme, 'palette', $current-palette, 'primary', 'main'),
+        'color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-main)
       ),
       'hover': (
         'text': (
-          'color':
-            darken(
-              map.get($theme, 'palette', $current-palette, 'primary', 'main'),
-              10%
-            ),
+          'color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-light)
         ),
       ),
     ),
     'secondary': (
       'text': (
         'color':
-          map.get($theme, 'palette', $current-palette, 'secondary', 'main'),
+          var(--react-bedrock-theme-palette-#{$current-palette}-secondary-main),
       ),
       'hover': (
         'text': (
-          'color':
-            darken(
-              map.get($theme, 'palette', $current-palette, 'secondary', 'main'),
-              10%
-            ),
+          'color': var(--react-bedrock-theme-palette-#{$current-palette}-secondary-light)
         ),
       ),
     ),
     'accent': (
       'text': (
-        'color': map.get($theme, 'palette', $current-palette, 'accent', 'main'),
+        'color': var(--react-bedrock-theme-palette-#{$current-palette}-accent-main),
       ),
       'hover': (
         'text': (
-          'color':
-            darken(
-              map.get($theme, 'palette', $current-palette, 'accent', 'main'),
-              10%
-            ),
+          'color': var(--react-bedrock-theme-palette-#{$current-palette}-accent-light)
         ),
       ),
     ),

--- a/libs/styles/src/components/button/_default-button.scss
+++ b/libs/styles/src/components/button/_default-button.scss
@@ -1,22 +1,25 @@
 @use 'sass:map';
 @use 'sass:color';
 
+@function primary-main-color($current-palette) {
+  @return --react-bedrock-theme-palette-#{$current-palette}-primary-main
+}
+
 $default-button: (
   'contained': (
-    'shadow': map.get($theme, 'shadow', 'box', 'xs'),
+    'shadow': --react-bedrock-theme-shadow-box-xs,
     'primary': (
       'background': (
-        'color': map.get($theme, 'palette', $current-palette, 'primary', 'main'),
+        'color': --react-bedrock-theme-palette-#{$current-palette}-primary-main,
       ),
       'text': (
-        'color':
-          map.get($theme, 'palette', $current-palette, 'primary', 'contrast-text'),
+        'color': --react-bedrock-theme-palette-#{$current-palette}-primary-contrast-text
       ),
       'hover': (
         'background': (
           'color':
             color.scale(
-              map.get($theme, 'palette', $current-palette, 'primary', 'main'),
+              primary-main-color($current-palette),
               $lightness: -10%
             ),
         ),

--- a/libs/styles/src/components/button/_default-button.scss
+++ b/libs/styles/src/components/button/_default-button.scss
@@ -2,62 +2,62 @@ $default-button: (
   'contained': (
     'shadow': var(--react-bedrock-theme-shadow-box-xs),
     'primary': (
-      'background-color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-main),
-      'text-color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-contrast-text),
-      'hover-background-color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-light)
+      'background-color': var(--react-bedrock-theme-palette-primary-main),
+      'text-color': var(--react-bedrock-theme-palette-primary-contrast-text),
+      'hover-background-color': var(--react-bedrock-theme-palette-primary-light)
     ),
     'secondary': (
-      'background-color': var(--react-bedrock-theme-palette-#{$current-palette}-secondary-main),
-      'text-color': var(--react-bedrock-theme-palette-#{$current-palette}-secondary-contrast-text),
-      'hover-background-color': var(--react-bedrock-theme-palette-#{$current-palette}-secondary-light)
+      'background-color': var(--react-bedrock-theme-palette-secondary-main),
+      'text-color': var(--react-bedrock-theme-palette-secondary-contrast-text),
+      'hover-background-color': var(--react-bedrock-theme-palette-secondary-light)
     ),
     'accent': (
-      'background-color': var(--react-bedrock-theme-palette-#{$current-palette}-accent-main),
-      'text-color': var(--react-bedrock-theme-palette-#{$current-palette}-accent-contrast-text),
-      'hover-background-color': var(--react-bedrock-theme-palette-#{$current-palette}-accent-light)
+      'background-color': var(--react-bedrock-theme-palette-accent-main),
+      'text-color': var(--react-bedrock-theme-palette-accent-contrast-text),
+      'hover-background-color': var(--react-bedrock-theme-palette-accent-light)
     ),
   ),
   'outlined': (
     'shadow': var(--react-bedrock-theme-shadow-box-xs),
     'border': var(--react-bedrock-theme-border-thin),
     'primary': (
-      'border-color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-main),
-      'text-color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-main),
+      'border-color': var(--react-bedrock-theme-palette-primary-main),
+      'text-color': var(--react-bedrock-theme-palette-primary-main),
       'hover': (
-        'border-color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-light),
-        'text-color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-light)
+        'border-color': var(--react-bedrock-theme-palette-primary-light),
+        'text-color': var(--react-bedrock-theme-palette-primary-light)
       ),
     ),
     'secondary': (
-      'border-color': var(--react-bedrock-theme-palette-#{$current-palette}-secondary-main),
-      'text-color': var(--react-bedrock-theme-palette-#{$current-palette}-secondary-main),
+      'border-color': var(--react-bedrock-theme-palette-secondary-main),
+      'text-color': var(--react-bedrock-theme-palette-secondary-main),
       'hover': (
-        'border-color': var(--react-bedrock-theme-palette-#{$current-palette}-secondary-light),
-        'text-color': var(--react-bedrock-theme-palette-#{$current-palette}-secondary-light)
+        'border-color': var(--react-bedrock-theme-palette-secondary-light),
+        'text-color': var(--react-bedrock-theme-palette-secondary-light)
       ),
     ),
     'accent': (
-      'border-color': var(--react-bedrock-theme-palette-#{$current-palette}-accent-main),
-      'text-color': var(--react-bedrock-theme-palette-#{$current-palette}-accent-main),
+      'border-color': var(--react-bedrock-theme-palette-accent-main),
+      'text-color': var(--react-bedrock-theme-palette-accent-main),
       'hover': (
-        'border-color': var(--react-bedrock-theme-palette-#{$current-palette}-accent-light),
-        'text-color': var(--react-bedrock-theme-palette-#{$current-palette}-accent-light)
+        'border-color': var(--react-bedrock-theme-palette-accent-light),
+        'text-color': var(--react-bedrock-theme-palette-accent-light)
       ),
     ),
   ),
   'text': (
     'shadow': var(--react-bedrock-theme-shadow-box-none),
     'primary': (
-      'text-color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-main),
-      'hover-text-color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-light)
+      'text-color': var(--react-bedrock-theme-palette-primary-main),
+      'hover-text-color': var(--react-bedrock-theme-palette-primary-light)
     ),
     'secondary': (
-      'text-color': var(--react-bedrock-theme-palette-#{$current-palette}-secondary-main),
-      'hover-text-color': var(--react-bedrock-theme-palette-#{$current-palette}-secondary-light)
+      'text-color': var(--react-bedrock-theme-palette-secondary-main),
+      'hover-text-color': var(--react-bedrock-theme-palette-secondary-light)
     ),
     'accent': (
-      'text-color': var(--react-bedrock-theme-palette-#{$current-palette}-accent-main),
-      'hover-text-color': var(--react-bedrock-theme-palette-#{$current-palette}-accent-light)
+      'text-color': var(--react-bedrock-theme-palette-accent-main),
+      'hover-text-color': var(--react-bedrock-theme-palette-accent-light)
     ),
   ),
 );

--- a/libs/styles/src/components/button/_default-button.scss
+++ b/libs/styles/src/components/button/_default-button.scss
@@ -2,129 +2,62 @@ $default-button: (
   'contained': (
     'shadow': var(--react-bedrock-theme-shadow-box-xs),
     'primary': (
-      'background': (
-        'color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-main),
-      ),
-      'text': (
-        'color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-contrast-text)
-      ),
-      'hover': (
-        'background': (
-          'color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-light)
-        ),
-      ),
+      'background-color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-main),
+      'text-color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-contrast-text),
+      'hover-background-color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-light)
     ),
     'secondary': (
-      'background': (
-        'color': var(--react-bedrock-theme-palette-#{$current-palette}-secondary-main)
-      ),
-      'text': (
-        'color': var(--react-bedrock-theme-palette-#{$current-palette}-secondary-contrast-text)
-      ),
-      'hover': (
-        'background': (
-          'color': var(--react-bedrock-theme-palette-#{$current-palette}-secondary-light)
-        ),
-      ),
+      'background-color': var(--react-bedrock-theme-palette-#{$current-palette}-secondary-main),
+      'text-color': var(--react-bedrock-theme-palette-#{$current-palette}-secondary-contrast-text),
+      'hover-background-color': var(--react-bedrock-theme-palette-#{$current-palette}-secondary-light)
     ),
     'accent': (
-      'background': (
-        'color': var(--react-bedrock-theme-palette#{$current-palette}-accent-main),
-      ),
-      'text': (
-        'color': var(--react-bedrock-theme-palette-#{$current-palette}-accent-contrast-text)
-      ),
-      'hover': (
-        'background': (
-          'color': var(--react-bedrock-theme-palette-#{$current-palette}-accent-light)
-        ),
-      ),
+      'background-color': var(--react-bedrock-theme-palette-#{$current-palette}-accent-main),
+      'text-color': var(--react-bedrock-theme-palette-#{$current-palette}-accent-contrast-text),
+      'hover-background-color': var(--react-bedrock-theme-palette-#{$current-palette}-accent-light)
     ),
   ),
   'outlined': (
     'shadow': var(--react-bedrock-theme-shadow-box-xs),
     'border': var(--react-bedrock-theme-border-thin),
     'primary': (
-      'border': (
-        'color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-main),
-      ),
-      'text': (
-        'color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-main),
-      ),
+      'border-color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-main),
+      'text-color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-main),
       'hover': (
-        'border': (
-          'color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-light)
-        ),
-        'text': (
-          'color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-light)
-        ),
+        'border-color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-light),
+        'text-color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-light)
       ),
     ),
     'secondary': (
-      'border': (
-        'color': var(--react-bedrock-theme-palette-#{$current-palette}-secondary-main),
-      ),
-      'text': (
-        'color': var(--react-bedrock-theme-palette-#{$current-palette}-secondary-main),
-      ),
+      'border-color': var(--react-bedrock-theme-palette-#{$current-palette}-secondary-main),
+      'text-color': var(--react-bedrock-theme-palette-#{$current-palette}-secondary-main),
       'hover': (
-        'border': (
-          'color': var(--react-bedrock-theme-palette-#{$current-palette}-secondary-light)
-        ),
-        'text': (
-          'color': var(--react-bedrock-theme-palette-#{$current-palette}-secondary-light)
-        ),
+        'border-color': var(--react-bedrock-theme-palette-#{$current-palette}-secondary-light),
+        'text-color': var(--react-bedrock-theme-palette-#{$current-palette}-secondary-light)
       ),
     ),
     'accent': (
-      'border': (
-        'color': var(--react-bedrock-theme-palette-#{$current-palette}-accent-main),
-      ),
-      'text': (
-        'color': var(--react-bedrock-theme-palette-#{$current-palette}-accent-main),
-      ),
+      'border-color': var(--react-bedrock-theme-palette-#{$current-palette}-accent-main),
+      'text-color': var(--react-bedrock-theme-palette-#{$current-palette}-accent-main),
       'hover': (
-        'border': (
-          'color': var(--react-bedrock-theme-palette-#{$current-palette}-accent-light)
-        ),
-        'text': (
-          'color': var(--react-bedrock-theme-palette-#{$current-palette}-accent-light)
-        ),
+        'border-color': var(--react-bedrock-theme-palette-#{$current-palette}-accent-light),
+        'text-color': var(--react-bedrock-theme-palette-#{$current-palette}-accent-light)
       ),
     ),
   ),
   'text': (
     'shadow': var(--react-bedrock-theme-shadow-box-none),
     'primary': (
-      'text': (
-        'color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-main)
-      ),
-      'hover': (
-        'text': (
-          'color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-light)
-        ),
-      ),
+      'text-color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-main),
+      'hover-text-color': var(--react-bedrock-theme-palette-#{$current-palette}-primary-light)
     ),
     'secondary': (
-      'text': (
-        'color':
-          var(--react-bedrock-theme-palette-#{$current-palette}-secondary-main),
-      ),
-      'hover': (
-        'text': (
-          'color': var(--react-bedrock-theme-palette-#{$current-palette}-secondary-light)
-        ),
-      ),
+      'text-color': var(--react-bedrock-theme-palette-#{$current-palette}-secondary-main),
+      'hover-text-color': var(--react-bedrock-theme-palette-#{$current-palette}-secondary-light)
     ),
     'accent': (
-      'text': (
-        'color': var(--react-bedrock-theme-palette-#{$current-palette}-accent-main),
-      ),
-      'hover': (
-        'text': (
-          'color': var(--react-bedrock-theme-palette-#{$current-palette}-accent-light)
-        ),
-      ),
+      'text-color': var(--react-bedrock-theme-palette-#{$current-palette}-accent-main),
+      'hover-text-color': var(--react-bedrock-theme-palette-#{$current-palette}-accent-light)
     ),
   ),
 );

--- a/libs/styles/src/components/paper/_default-paper.scss
+++ b/libs/styles/src/components/paper/_default-paper.scss
@@ -1,17 +1,17 @@
 $default-paper: (
   "corners": (
-    "rounded": map.get($theme, "shape", "border-radius", "sm"),
-    "squared": map.get($theme, "shape", "border-radius", "none")
+    "rounded": --react-bedrock-theme-shape-border-radius-sm,
+    "squared": --react-bedrock-theme-shape-border-radius-none
   ),
   "shadow": (
-    "none": map.get($theme, "shadows", "box", "none"),
-    "xs": map.get($theme, "shadows", "box", "xs"),
-    "xm": map.get($theme, "shadows", "box", "sm"),
-    "md": map.get($theme, "shadows", "box", "md"),
-    "lg": map.get($theme, "shadows", "box", "lg"),
-    "xl": map.get($theme, "shadows", "box", "xl"),
-    "2xl": map.get($theme, "shadows", "box", "2xl")
+    "none": --react-bedrock-theme-shadows-box-none,
+    "xs": --react-bedrock-theme-shadows-box-xs,
+    "xm": --react-bedrock-theme-shadows-box-sm,
+    "md": --react-bedrock-theme-shadows-box-md,
+    "lg": --react-bedrock-theme-shadows-box-lg,
+    "xl": --react-bedorck-theme-shadows-box-xl,
+    "2xl": --react-bedrock-theme-shadows-box-2xl
   ),
   "padding": "1rem 2rem",
-  "outlined": map.get($theme, "borders", "thin")
+  "outlined": --react-bedrock-theme-borders-thin
 );

--- a/libs/styles/src/components/paper/_default-paper.scss
+++ b/libs/styles/src/components/paper/_default-paper.scss
@@ -1,17 +1,17 @@
 $default-paper: (
   "corners": (
-    "rounded": --react-bedrock-theme-shape-border-radius-sm,
-    "squared": --react-bedrock-theme-shape-border-radius-none
+    "rounded": var(--react-bedrock-theme-shape-border-radius-sm),
+    "squared": var(--react-bedrock-theme-shape-border-radius-none)
   ),
   "shadow": (
-    "none": --react-bedrock-theme-shadows-box-none,
-    "xs": --react-bedrock-theme-shadows-box-xs,
-    "xm": --react-bedrock-theme-shadows-box-sm,
-    "md": --react-bedrock-theme-shadows-box-md,
-    "lg": --react-bedrock-theme-shadows-box-lg,
-    "xl": --react-bedorck-theme-shadows-box-xl,
-    "2xl": --react-bedrock-theme-shadows-box-2xl
+    "none": var(--react-bedrock-theme-shadows-box-none),
+    "xs": var(--react-bedrock-theme-shadows-box-xs),
+    "sm": var(--react-bedrock-theme-shadows-box-sm),
+    "md": var(--react-bedrock-theme-shadows-box-md),
+    "lg": var(--react-bedrock-theme-shadows-box-lg),
+    "xl": var(--react-bedrock-theme-shadows-box-xl),
+    "2xl": var(--react-bedrock-theme-shadows-box-2xl)
   ),
   "padding": "1rem 2rem",
-  "outlined": --react-bedrock-theme-borders-thin
+  "outlined": var(--react-bedrock-theme-borders-thin)
 );

--- a/libs/styles/src/html-elements/_default-html-elements.scss
+++ b/libs/styles/src/html-elements/_default-html-elements.scss
@@ -2,80 +2,42 @@
 
 $default-html-elements: (
   "h1": (
-    "font": (
-      "weight": map.get($theme, "typography", "font", "weight", "light"),
-      "size": map.get($theme, "typography", "font", "size", "8xl")
-    ),
-    "line": (
-      "height": map.get($theme, "typography", "line-height", "lg"),
-    ),
-    "letter": (
-      "spacing": map.get($theme, "typography", "tracking", "tight")
-    )
+    "font-weight": var(--react-bedrock-theme-typography-font-weight-light),
+    "font-size": var(--react-bedrock-theme-typography-font-size-8xl),
+    "line-height": var(--react-bedrock-theme-typography-line-height-lg),
+    "letter-spacing": var(--react-bedrock-theme-typography-tracking-tight)
   ),
   "h2": (
-    "font": (
-      "weight": map.get($theme, "typography", "font", "weight", "light"),
-      "size": map.get($theme, "typography", "font", "size", "6xl")
-    ),
-    "line": (
-      "height": map.get($theme, "typography", "line-height", "sm")
-    ),
-    "letter": (
-      "spacing": map.get($theme, "typography", "tracking", "normal")
-    )
+    "font-weight": var(--react-bedrock-theme-typography-font-weight-light),
+    "font-size": var(--react-bedrock-theme-typography-font-size-6xl),
+    "line-height": var(--react-bedrock-theme-typography-line-height-sm),
+    "letter-spacing": var(--react-bedrock-theme-typography-tracking-normal)
   ),
   "h3": (
-    "font": (
-      "weight": map.get($theme, "typography", "font", "weight", "normal"),
-      "size": map.get($theme, "typography", "font", "size", "5xl")
-    ),
-    "line": (
-      "height": map.get($theme, "typography", "line-height", "sm")
-    ),
-    "letter": (
-      "spacing": map.get($theme, "typography", "tracking", "normal")
-    )
+    "font-weight": var(--react-bedrock-theme-typography-font-weight-normal),
+    "font-size": var(--react-bedrock-theme-typography-font-size-5xl),
+    "line-height": var(--react-bedrock-theme-typography-line-height-sm),
+    "letter-spacing": var(--react-bedrock-theme-typography-tracking-normal)
   ),
   "h4": (
-    "font": (
-      "weight": map.get($theme, "typography", "font", "weight", "normal"),
-      "size": map.get($theme, "typography", "font", "size", "3xl")
-    ),
-    "line": (
-      "height": map.get($theme, "typography", "line-height", "sm")
-    ),
-    "letter": (
-      "spacing": map.get($theme, "typography", "tracking", "normal")
-    )
+    "font-weight": var(--react-bedrock-theme-typography-font-weight-normal),
+    "font-size": var(--react-bedrock-theme-typography-font-size-3xl),
+    "line-height": var(--react-bedrock-theme-typography-line-height-sm),
+    "letter-spacing": var(--react-bedrock-theme-typography-tracking-normal)
   ),
   "h5": (
-    "font": (
-      "weight": map.get($theme, "typography", "font", "weight", "normal"),
-      "size": map.get($theme, "typography", "font", "size", "2xl")
-    ),
-    "line": (
-      "height": map.get($theme, "typography", "line-height", "sm")
-    ),
-    "letter": (
-      "spacing": map.get($theme, "typography", "tracking", "normal")
-    )
+    "font-weight": var(--react-bedrock-theme-typography-font-weight-normal),
+    "font-size": var(--react-bedrock-theme-typography-font-size-2xl),
+    "line-height": var(--react-bedrock-theme-typography-line-height-sm),
+    "letter-spacing": var(--react-bedrock-theme-typography-tracking-normal)
   ),
   "h6": (
-    "font": (
-      "weight": map.get($theme, "typography", "font", "weight", "medium"),
-      "size": map.get($theme, "typography", "font", "size", "xl")
-    ),
-    "line": (
-      "height": map.get($theme, "typography", "line-height", "md")
-    ),
-    "letter": (
-      "spacing": map.get($theme, "typography", "tracking", "normal")
-    )
+    "font-weight": var(--react-bedrock-theme-typography-font-weight-medium),
+    "font-size": var(--react-bedrock-theme-typography-font-size-xl),
+    "line-height": var(--react-bedrock-theme-typography-line-height-md),
+    "letter-spacing": var(--react-bedrock-theme-typography-tracking-normal)
   ),
   "body": (
-    "font": (
-      "family": map.get($theme, "typography", "font", "family", "sans")
-    )
+    "font-family": var(--react-bedrock-theme-typography-font-family-sans)
   )
 );

--- a/libs/styles/src/html-elements/_set-html-elements.scss
+++ b/libs/styles/src/html-elements/_set-html-elements.scss
@@ -1,6 +1,6 @@
 @use 'sass:map';
 @import './default-html-elements';
-@import '../utility/scss-map-to-element-styles';
+@import '../utility/map-to-styles';
 
 $html-elements: ();
 
@@ -8,6 +8,6 @@ $html-elements: ();
   $html-elements: map.deep-merge($default-html-elements, $html-elements-config) !global;
 
   :root {
-    @include scss-map-to-element-styles($html-elements);
+    @include map-to-styles($html-elements);
   }
 };

--- a/libs/styles/src/theme/_default-palette.scss
+++ b/libs/styles/src/theme/_default-palette.scss
@@ -1,47 +1,48 @@
+@use 'sass:color';
 @import '../colors/index';
 
 $default-palette: (
   'light': (
     'primary': (
       'main': $blue-700,
-      'light': $blue-400,
-      'dark': $blue-800,
+      'light': color.scale($blue-700, $lightness: 15%),
+      'dark': color.scale($blue-700, $lightness: -15%),
       'contrast-text': white,
     ),
     'secondary': (
       'main': $purple-500,
-      'light': $purple-300,
-      'dark': $purple-700,
+      'light': color.scale($purple-500, $lightness: 15%),
+      'dark': color.scale($purple-500, $lightness: -15%),
       'contrast-text': white,
     ),
     'accent': (
       'main': $purple-500,
-      'light': $purple-300,
-      'dark': $purple-700,
+      'light': color.scale($purple-500, $lightness: 15%),
+      'dark': color.scale($purple-500, $lightness: -15%),
       'contrast-text': white,
     ),
     'error': (
       'main': $red-700,
-      'light': $red-400,
-      'dark': $red-800,
+      'light': color.scale($red-700, $lightness: 15%),
+      'dark': color.scale($red-700, $lightness: -15%),
       'contrast-text': white,
     ),
     'warning': (
       'main': $orange-700,
-      'light': $orange-500,
-      'dark': $orange-900,
+      'light': color.scale($orange-700, $lightness: 15%),
+      'dark': color.scale($orange-700, $lightness: -15%),
       'contrast-text': white,
     ),
     'info': (
       'main': $blue-600,
-      'light': $blue-400,
-      'dark': $blue-800,
+      'light': color.scale($blue-600, $lightness: 15%),
+      'dark': color.scale($blue-600, $lightness: -15%),
       'contrast-text': white,
     ),
     'success': (
       'main': $green-800,
-      'light': $green-500,
-      'dark': $green-900,
+      'light': color.scale($green-800, $lightness: 15%),
+      'dark': color.scale($green-800, $lightness: -15%),
       'contrast-text': white,
     ),
     'text': (
@@ -57,44 +58,44 @@ $default-palette: (
   'dark': (
     'primary': (
       'main': $blue-700,
-      'light': $blue-400,
-      'dark': $blue-800,
+      'light': color.scale($blue-700, $lightness: 15%),
+      'dark': color.scale($blue-700, $lightness: -15%),
       'contrast-text': white,
     ),
     'secondary': (
       'main': $purple-500,
-      'light': $purple-300,
-      'dark': $purple-700,
+      'light': color.scale($purple-500, $lightness: 15%),
+      'dark': color.scale($purple-500, $lightness: -15%),
       'contrast-text': white,
     ),
     'accent': (
       'main': $purple-500,
-      'light': $purple-300,
-      'dark': $purple-700,
+      'light': color.scale($purple-500, $lightness: 15%),
+      'dark': color.scale($purple-500, $lightness: -15%),
       'contrast-text': white,
     ),
     'error': (
       'main': $red-700,
-      'light': $red-400,
-      'dark': $red-800,
+      'light': color.scale($red-700, $lightness: 15%),
+      'dark': color.scale($red-700, $lightness: -15%),
       'contrast-text': white,
     ),
     'warning': (
       'main': $orange-700,
-      'light': $orange-500,
-      'dark': $orange-900,
+      'light': color.scale($red-700, $lightness: 15%),
+      'dark': color.scale($red-700, $lightness: -15%),
       'contrast-text': white,
     ),
     'info': (
       'main': $blue-600,
-      'light': $blue-400,
-      'dark': $blue-800,
+      'light': color.scale($blue-600, $lightness: 15%),
+      'dark': color.scale($blue-600, $lightness: -15%),
       'contrast-text': white,
     ),
     'success': (
       'main': $green-800,
-      'light': $green-500,
-      'dark': $green-900,
+      'light': color.scale($green-800, $lightness: 15%),
+      'dark': color.scale($green-800, $lightness: -15%),
       'contrast-text': white,
     ),
     'text': (

--- a/libs/styles/src/theme/_set-theme.scss
+++ b/libs/styles/src/theme/_set-theme.scss
@@ -1,10 +1,13 @@
 @use 'sass:map';
 @import './default-theme';
+@import '../utility/scss-map-to-css-vars';
 
 $current-palette: 'light';
 $theme: ();
 
 @mixin set-theme($theme-config: ()) {
+  $theme: map.deep-merge($default-theme, $theme) !global;
+
   :root {
     @include scss-map-to-css-vars($theme, 'react-bedrock-theme');
   }

--- a/libs/styles/src/theme/_set-theme.scss
+++ b/libs/styles/src/theme/_set-theme.scss
@@ -1,14 +1,25 @@
 @use 'sass:map';
 @import './default-theme';
-@import '../utility/scss-map-to-css-vars';
+@import '../utility/nested-map-to-css-vars';
 
-$current-palette: 'light';
 $theme: ();
 
 @mixin set-theme($theme-config: ()) {
   $theme: map.deep-merge($default-theme, $theme) !global;
 
   :root {
-    @include scss-map-to-css-vars($theme, 'react-bedrock-theme');
+    @each $key, $value in $theme {
+      @if($key != 'palette') {
+        @include nested-map-to-css-vars($value, react-bedrock-theme-#{$key});
+      } @else {
+        @include nested-map-to-css-vars(map.get($value, 'light'), react-bedrock-theme-palette)
+      }
+    }
+  }
+
+  @each $key, $value in map.get($theme, 'palette') {
+    :root[data-theme='#{$key}'] {
+      @include nested-map-to-css-vars($value, 'react-bedrock-palette');
+    }
   }
 }

--- a/libs/styles/src/theme/_set-theme.scss
+++ b/libs/styles/src/theme/_set-theme.scss
@@ -9,15 +9,17 @@ $theme: ();
 
   :root {
     @each $key, $value in $theme {
-      @if($key != 'palette') {
-        @include nested-map-to-css-vars($value, react-bedrock-theme-#{$key});
+      @if($key == 'palette') {
+        // set light palette as default
+        @include nested-map-to-css-vars(map.get($value, 'light'), react-bedrock-theme-palette);
       } @else {
-        @include nested-map-to-css-vars(map.get($value, 'light'), react-bedrock-theme-palette)
+        @include nested-map-to-css-vars($value, react-bedrock-theme-#{$key});
       }
     }
   }
 
   @each $key, $value in map.get($theme, 'palette') {
+    // configure all palettes through css custom data-theme attribute
     :root[data-theme='#{$key}'] {
       @include nested-map-to-css-vars($value, 'react-bedrock-palette');
     }

--- a/libs/styles/src/theme/_set-theme.scss
+++ b/libs/styles/src/theme/_set-theme.scss
@@ -5,5 +5,7 @@ $current-palette: 'light';
 $theme: ();
 
 @mixin set-theme($theme-config: ()) {
-  $theme: map.deep-merge($default-theme, $theme-config) !global;
+  :root {
+    @include scss-map-to-css-vars($theme, 'react-bedrock-theme');
+  }
 }

--- a/libs/styles/src/utility/_map-to-styles.scss
+++ b/libs/styles/src/utility/_map-to-styles.scss
@@ -1,6 +1,6 @@
 @use 'sass:meta';
 
-@mixin scss-map-to-element-styles($map) {
+@mixin map-to-styles($map) {
   @each $element, $inner-map in $map {
     #{$element} {
       @each $name, $value in $inner-map {

--- a/libs/styles/src/utility/_nested-map-to-css-vars.scss
+++ b/libs/styles/src/utility/_nested-map-to-css-vars.scss
@@ -1,7 +1,7 @@
 @use 'sass:meta';
 
 // create mixin
-@mixin scss-map-to-css-vars($map, $prefix, $key: '') {
+@mixin nested-map-to-css-vars($map, $prefix, $key: '') {
   @each $name, $value in $map {
     // copy map key to track current spot
     $key-copy: $key;
@@ -11,7 +11,7 @@
     $key: #{$key}-#{$name};
 
     @if meta.type-of($value) == 'map' or meta.type-of($value) == 'list' {
-      @include scss-map-to-css-vars($value, $prefix, $key);
+      @include nested-map-to-css-vars($value, $prefix, $key);
     } @else {
       --#{$prefix}#{$key}: #{$value};
     }

--- a/libs/styles/src/utility/_scss-map-to-element-styles.scss
+++ b/libs/styles/src/utility/_scss-map-to-element-styles.scss
@@ -1,43 +1,10 @@
 @use 'sass:meta';
 
-@mixin map-to-styles-helper($map, $key) {
-  @each $name, $value in $map {
-    // copy map key to track current spot
-    $key-copy: $key;
-
-    // create name for CSS custom property that contains:
-    // current key + child key from nested map
-    @if($key) {
-      $key: #{$key}-#{$name};
-    }
-    @else {
-      $key: $name;
-    }
-    
-
-    @if meta.type-of($value) == 'map' or meta.type-of($value) == 'list' {
-      @include map-to-styles-helper($value, $key);
-    } @else {
-      #{$key}: #{$value};
-    }
-
-    // reset map key for next iteration
-    $key: $key-copy;
-  }
-};
-
-// create mixin
 @mixin scss-map-to-element-styles($map) {
   @each $element, $inner-map in $map {
     #{$element} {
       @each $name, $value in $inner-map {
-        $key: $name;
-
-        @if meta.type-of($value) == 'map' or meta.type-of($value) == 'list' {
-          @include map-to-styles-helper($value, $key);
-        } @else {
-          #{$key}: #{$value};
-        }
+        #{$name}: #{$value};
       }
     }
   }


### PR DESCRIPTION
Closes #22 

The main thing being done here is that the theme is now being referenced through css variables instead of the scss map. However there are some other small things going on

- Before I was changing all of the component variables based on the theme, but we really only want the palette to change. I updated the components to all just reference palette variables and then have those palette variables change when the theme changes through the custom css data-theme attribute
- I decided that having the buttons map completely exploded was harder to read. So, for any keys that don't have multiple children I just condensed the key and it's children down to one key. This changed the file from 199 lines to 63 without affecting functionality whatsoever :)
- For the Elements map, since they are directly correlating to the css properties, I decided it makes more sense for the key name to be the actual css property instead of nesting them. This makes it easier to tell what properties are being set and also simplifies setting the property values as they will just be a 2 layer deep map where the outer key is always the `element` and the inner key is always the css property
- We might run into other issues with this later, but if we convert a value to a css variable, then we can no longer run scss functions on them. These scss functions can actually do some pretty cool things, so right now I am using the `colors.scale()` function in the `$theme` map before they are converted to CSS variables